### PR TITLE
Add .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,4 @@
+build:
+    image: latest
+python:
+    version: 3.6


### PR DESCRIPTION
Add readthedocs YAML configuration file for correct `autodoc` generation on RTD. 
This fixes issue #45 that was caused by the fact that RTD does not support python 3.6 by default. RTD picks instead python 3.5. Modules and function docstrings were missing from documentation as their import failed due to the presence of PEP 498 string formatting, that is not supported by python 3.5.
The documentation is tested on my fork, and the result of this fix are visible at 
https://gnpy-test.readthedocs.io/en/issue_45/source/gnpy.html
